### PR TITLE
update actions/cache version

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Get yarn cache
       id: yarn-cache
       run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
-    - uses: actions/cache@v1
+    - uses: actions/cache@v3
       with:
         path: ${{ steps.yarn-cache.outputs.dir }}
         key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}


### PR DESCRIPTION
v1 and v2 have been retired
https://github.blog/changelog/2025-01-15-github-actions-ubuntu-20-runner-image-brownout-dates-and-other-breaking-changes/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down